### PR TITLE
Bug Fix: Mono checkbox always unchecked after opening popup

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -82,7 +82,7 @@ browser.tabs.query({ currentWindow: true, active: true }).then(tabs => {
 				pan.parentElement.querySelector('.target').innerHTML = '' + pan.value
 			})
 			const mono = node.querySelector('.element-mono')
-			mono.value = settings.mono || false
+			mono.checked = settings.mono || false
 			mono.addEventListener('change', _ => {
 				applySettings(fid, elid, { mono: mono.checked })
 			})


### PR DESCRIPTION
### Problem
If I check Mono in the popup window, close the popup and open it again, Mono is always unchecked.

### Fix
In the code, you use 
`mono.value = settings.mono || false`

I also wrote
`mono.checked = settings.mono || false`
I kept the `mono.value` line, just to be sure nothing breaks